### PR TITLE
Updated containers

### DIFF
--- a/compose/docker-bitcoin.yml
+++ b/compose/docker-bitcoin.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   bitcoind:
     container_name: bitcoind
-    image: lncm/bitcoind:v27.0
+    image: lncm/bitcoind:v28.0
     command: "${APP_BITCOIN_COMMAND}"
     restart: unless-stopped
     user: "${APP_BITCOIND_USER_INFO}"
@@ -18,7 +18,7 @@ services:
         ipv4_address: "${APP_BITCOIND_IP}"
   bitcoin_gui:
     container_name: bitcoin_gui
-    image: getumbrel/umbrel-bitcoin:v0.7.0
+    image: getumbrel/umbrel-bitcoin:v0.8.0
     restart: on-failure
     depends_on: [bitcoind]
     ports:

--- a/compose/docker-electrs.yml
+++ b/compose/docker-electrs.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   electrs:
     container_name: electrs
-    image: getumbrel/electrs:v0.10.2
+    image: getumbrel/electrs:v0.10.7
     restart: always
     user: "${APP_ELECTRS_USER_INFO}"
     ports:
@@ -24,7 +24,7 @@ services:
         ipv4_address: "${APP_ELECTRS_IP}"
   electrs_gui:
     container_name: electrs_gui
-    image: getumbrel/umbrel-electrs:v1.0.2
+    image: getumbrel/umbrel-electrs:v1.0.4
     restart: on-failure
     depends_on: [electrs]
     ports:
@@ -69,7 +69,7 @@ services:
         ipv4_address: "${APP_MEMPOOL_IP}"
   mempool_space_web:
     container_name: mempool_space_web
-    image: mempool/frontend:v2.5.0
+    image: mempool/frontend:v3.0.1
     user: "${APP_MEMPOOL_USER_INFO}"
     init: true
     restart: on-failure
@@ -88,7 +88,7 @@ services:
         ipv4_address: "${APP_MEMPOOL_IP}"
   mempool_space_api:
     container_name: mempool_space_api
-    image: mempool/backend:v2.5.0
+    image: mempool/backend:v3.0.1
     user: "${APP_MEMPOOL_USER_INFO}"
     init: true
     restart: on-failure
@@ -123,6 +123,7 @@ services:
       LND_MACAROON_PATH: "/lnd/data/chain/bitcoin/${APP_CRYPTO_NETWORK}/readonly.macaroon"
       LND_REST_API_URL: "https://${APP_LIGHTNING_NODE_IP}:${APP_LIGHTNING_NODE_REST_PORT}"
       LND_TIMEOUT: 120000
+      NODE_OPTIONS: "--max-old-space-size=2048"
     networks:
       default:
         ipv4_address: "${APP_MEMPOOL_API_IP}"

--- a/compose/docker-lightning.yml
+++ b/compose/docker-lightning.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   lnd:
     container_name: lnd
-    image: lightninglabs/lnd:v0.17.4-beta
+    image: lightninglabs/lnd:v0.18.3-beta
     command: "${APP_LIGHTNING_COMMAND}"
     restart: unless-stopped
     user: "${APP_LND_USER_INFO}"

--- a/start.sh
+++ b/start.sh
@@ -405,6 +405,8 @@ BIN_ARGS_BITCOIND+=( "-zmqpubrawblock=tcp://0.0.0.0:${STACK_BITCOIND_PUB_RAW_BLO
 BIN_ARGS_BITCOIND+=( "-zmqpubrawtx=tcp://0.0.0.0:${STACK_BITCOIND_PUB_RAW_TX_PORT}" )
 BIN_ARGS_BITCOIND+=( "-zmqpubhashblock=tcp://0.0.0.0:28334" )
 BIN_ARGS_BITCOIND+=( "-zmqpubsequence=tcp://0.0.0.0:28335" )
+BIN_ARGS_BITCOIND+=( "-deprecatedrpc=create_bd" )
+BIN_ARGS_BITCOIND+=( "-deprecatedrpc=warnings" )
 
 # Exporting the generated command to the compose file.
 export APP_BITCOIN_COMMAND=$(IFS=" "; echo -e "${BIN_ARGS_BITCOIND[@]}" | tr -d '"')


### PR DESCRIPTION
- bitcoind from v27.0 to v28.0
- electrum from v0.10.2 to v0.10.7
- umbrel electrum gui from v1.0.2 to v1.0.4
- mempool from v2.5.0 to v3.0.1
- lnd from v0.17.4-beta to v0.18.3-beta