### PR TITLE
Updated containers

### DIFF
--- a/compose/docker-bitcoin.yml
+++ b/compose/docker-bitcoin.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   bitcoind:
     container_name: bitcoind
-    image: lncm/bitcoind:v28.0
+    image: getumbrel/bitcoind:v28.0
     command: "${APP_BITCOIN_COMMAND}"
     restart: unless-stopped
     user: "${APP_BITCOIND_USER_INFO}"

--- a/compose/docker-extras.yml
+++ b/compose/docker-extras.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   ordinals:
     container_name: ordinals
-    image: nmfretz/ord:0.18.2
+    image: nmfretz/ord:0.20.0
     restart: on-failure
     ports:
       - "${APP_EXTRAS_ORDINALS_PORT}:80"
@@ -26,7 +26,7 @@ services:
         ipv4_address: ${APP_EXTRAS_ORDINALS_IP}
   adguard:
     container_name: adguard
-    image: adguard/adguardhome:v0.107.50
+    image: adguard/adguardhome:v0.107.54
     command:
       [
         "--no-check-update",
@@ -147,7 +147,7 @@ services:
         ipv4_address: ${APP_EXTRAS_LLAMA_GPT_UI_IP}
   lightning_terminal:
     container_name: lightning_terminal
-    image: lightninglabs/lightning-terminal:v0.13.0-alpha
+    image: lightninglabs/lightning-terminal:v0.13.6-alpha
     user: "${APP_LND_USER_INFO}"
     restart: on-failure
     stop_grace_period: 1m

--- a/compose/docker-tor.yml
+++ b/compose/docker-tor.yml
@@ -16,7 +16,7 @@ services:
         ipv4_address: "${APP_TOR_IP}"
   i2pd:
     container_name: i2pd
-    image: purplei2p/i2pd:release-2.52.0
+    image: purplei2p/i2pd:release-2.54.0
     command: "${APP_I2PD_COMMAND}"
     restart: on-failure
     user: "root"


### PR DESCRIPTION
- Release v1.4.0.
- Switched to Umbrel's bitcoind container as the one from lncm does not appear to have had any updates in a while. This will cause everything to resync. Give this some time.
- Updated the i2pd container and some of the extra containers to newer image versions.